### PR TITLE
Update JDK from Adopt to Zulu and use caching from setup-java action.

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -59,19 +59,13 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
       
-    - name: Set up JDK 11
+    - name: Set up JDK 11.0.3
       uses: actions/setup-java@v2
       with:
-        java-version: 11
-        distribution: 'adopt'
-      
-    - name: Cache Maven packages
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-m2
-
+          distribution: 'zulu'
+          java-version: 11.0.3
+          cache: 'maven'
+    
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1

--- a/.github/workflows/twitter-backend-pr-checker.yml
+++ b/.github/workflows/twitter-backend-pr-checker.yml
@@ -38,18 +38,12 @@ jobs:
         with:
           fetch-depth: 0
       
-      - name: Set up JDK 11
+      - name: Set up JDK 11.0.3
         uses: actions/setup-java@v2
         with:
-          java-version: 11
-          distribution: 'adopt'
-      
-      - name: Cache Maven packages
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          distribution: 'zulu'
+          java-version: 11.0.3
+          cache: 'maven'
       
       - name: Extract branch name
         shell: bash
@@ -99,19 +93,12 @@ jobs:
     - name: Checkout Code
       uses: actions/checkout@v2
     
-    - name: Set up JDK 11
+    - name: Set up JDK 11.0.3
       uses: actions/setup-java@v2
       with:
-        java-version: 11
-        distribution: 'adopt'
-    
-    - name: Cache Maven packages
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          ${{ runner.os }}-maven-
+        distribution: 'zulu'
+        java-version: 11.0.3
+        cache: 'maven'
     
     - name: Check Code Formatting
       run: |

--- a/.github/workflows/twitter-backend.yml
+++ b/.github/workflows/twitter-backend.yml
@@ -37,18 +37,12 @@ jobs:
         with:
           fetch-depth: 0
       
-      - name: Set up JDK 11
+      - name: Set up JDK 11.0.3
         uses: actions/setup-java@v2
         with:
-          java-version: 11
-          distribution: 'adopt'
-      
-      - name: Cache Maven packages
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          distribution: 'zulu'
+          java-version: 11.0.3
+          cache: 'maven'
 
       - name: Cache SonarCloud packages
         uses: actions/cache@v2
@@ -113,19 +107,12 @@ jobs:
     - name: Checkout Code
       uses: actions/checkout@v2
     
-    - name: Set up JDK 11
+    - name: Set up JDK 11.0.3
       uses: actions/setup-java@v2
       with:
-        java-version: 11
-        distribution: 'adopt'
-    
-    - name: Cache Maven packages
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          ${{ runner.os }}-maven-
+        distribution: 'zulu'
+        java-version: 11.0.3
+        cache: 'maven'
     
     - name: Check Code Formatting
       run: |


### PR DESCRIPTION
### Using the latest LTS and fixed (major) versions of the OpenJDK.

The AdoptOpenJDK has been discontinued since July 2021 (https://adoptopenjdk.net). This request is to switch the distribution from `adopt` to Azul `zulu`. When using Zulu you get all the latest updated (TCK Tested) builds for all versions of OpenJDK (even archived fixed versions and early access releases).